### PR TITLE
Define bitwise operations on 1d and multi-dimensional arrays.

### DIFF
--- a/src/clj_vapi/1d.clj
+++ b/src/clj_vapi/1d.clj
@@ -390,3 +390,55 @@
   float/1 (vtest-ge? [a1 a2] (lanewise-test-ge? FloatVector a1 a2))
   double/1 (vtest-ge? [a1 a2] (lanewise-test-ge? DoubleVector a1 a2)))
 
+;; ------------------ Bitwise Op FNs ------------------
+
+(defmacro lanewise-bit-and
+  [v-type a1 a2]
+  `(lanewise ~v-type bit-and VectorOperators/AND ~a1 ~a2))
+
+(extend-protocol p/VBitAnd
+  byte/1 (vbit-and [a1 a2] (lanewise-bit-and ByteVector a1 a2))
+  short/1 (vbit-and [a1 a2] (lanewise-bit-and ShortVector a1 a2))
+  int/1 (vbit-and [a1 a2] (lanewise-bit-and IntVector a1 a2))
+  long/1 (vbit-and [a1 a2] (lanewise-bit-and LongVector a1 a2)))
+
+(defmacro lanewise-bit-or
+  [v-type a1 a2]
+  `(lanewise ~v-type bit-or VectorOperators/OR ~a1 ~a2))
+
+(extend-protocol p/VBitOr
+  byte/1 (vbit-or [a1 a2] (lanewise-bit-or ByteVector a1 a2))
+  short/1 (vbit-or [a1 a2] (lanewise-bit-or ShortVector a1 a2))
+  int/1 (vbit-or [a1 a2] (lanewise-bit-or IntVector a1 a2))
+  long/1 (vbit-or [a1 a2] (lanewise-bit-or LongVector a1 a2)))
+
+(defmacro lanewise-bit-xor
+  [v-type a1 a2]
+  `(lanewise ~v-type bit-xor VectorOperators/XOR ~a1 ~a2))
+
+(extend-protocol p/VBitXor
+  byte/1 (vbit-xor [a1 a2] (lanewise-bit-xor ByteVector a1 a2))
+  short/1 (vbit-xor [a1 a2] (lanewise-bit-xor ShortVector a1 a2))
+  int/1 (vbit-xor [a1 a2] (lanewise-bit-xor IntVector a1 a2))
+  long/1 (vbit-xor [a1 a2] (lanewise-bit-xor LongVector a1 a2)))
+
+(defmacro lanewise-bit-not
+  [v-type a]
+  `(lanewise ~v-type bit-not VectorOperators/NOT ~a))
+
+(extend-protocol p/VBitNot
+  byte/1 (vbit-not [a] (lanewise-bit-not ByteVector a))
+  short/1 (vbit-not [a] (lanewise-bit-not ShortVector a))
+  int/1 (vbit-not [a] (lanewise-bit-not IntVector a))
+  long/1 (vbit-not [a] (lanewise-bit-not LongVector a)))
+
+(defmacro lanewise-bit-and-not
+  [v-type a1 a2]
+  `(lanewise ~v-type bit-and-not VectorOperators/AND_NOT ~a1 ~a2))
+
+(extend-protocol p/VBitAndNot
+  byte/1 (vbit-and-not [a1 a2] (lanewise-bit-and-not ByteVector a1 a2))
+  short/1 (vbit-and-not [a1 a2] (lanewise-bit-and-not ShortVector a1 a2))
+  int/1 (vbit-and-not [a1 a2] (lanewise-bit-and-not IntVector a1 a2))
+  long/1 (vbit-and-not [a1 a2] (lanewise-bit-and-not LongVector a1 a2)))
+

--- a/src/clj_vapi/core.clj
+++ b/src/clj_vapi/core.clj
@@ -52,3 +52,11 @@
 (defn vtest-gt? [x1 x2] (p/vtest-gt? x1 x2))
 (defn vtest-ge? [x1 x2] (p/vtest-ge? x1 x2))
 
+;; ------------------ Bitwise Op FNs ------------------
+
+(defn vbit-and [x1 x2] (p/vbit-and x1 x2))
+(defn vbit-or [x1 x2] (p/vbit-or x1 x2))
+(defn vbit-xor [x1 x2] (p/vbit-xor x1 x2))
+(defn vbit-not [x] (p/vbit-not x))
+(defn vbit-and-not [x1 x2] (p/vbit-and-not x1 x2))
+

--- a/src/clj_vapi/md.clj
+++ b/src/clj_vapi/md.clj
@@ -88,5 +88,10 @@
   p/VTestLT (vtest-lt? [x1 x2] (vtest-md p/vtest-lt? x1 x2))
   p/VTestLE (vtest-le? [x1 x2] (vtest-md p/vtest-le? x1 x2))
   p/VTestGT (vtest-gt? [x1 x2] (vtest-md p/vtest-gt? x1 x2))
-  p/VTestGE (vtest-ge? [x1 x2] (vtest-md p/vtest-ge? x1 x2)))
+  p/VTestGE (vtest-ge? [x1 x2] (vtest-md p/vtest-ge? x1 x2))
+  p/VBitAnd (vbit-and [x1 x2] (vmap-md p/vbit-and x1 x2))
+  p/VBitOr (vbit-or [x1 x2] (vmap-md p/vbit-or x1 x2))
+  p/VBitXor (vbit-xor [x1 x2] (vmap-md p/vbit-xor x1 x2))
+  p/VBitNot (vbit-not [x] (vmap-md p/vbit-not x))
+  p/VBitAndNot (vbit-and-not [x1 x2] (vmap-md p/vbit-and-not x1 x2)))
 

--- a/src/clj_vapi/protocols.clj
+++ b/src/clj_vapi/protocols.clj
@@ -46,3 +46,11 @@
 (defprotocol VTestGT (vtest-gt? [a1 a2]))
 (defprotocol VTestGE (vtest-ge? [a1 a2]))
 
+;; ------------------ Bitwise Op FNs ------------------
+
+(defprotocol VBitAnd (vbit-and [a1 a2]))
+(defprotocol VBitOr (vbit-or [a1 a2]))
+(defprotocol VBitXor (vbit-xor [a1 a2]))
+(defprotocol VBitNot (vbit-not [a]))
+(defprotocol VBitAndNot (vbit-and-not [a1 a2]))
+

--- a/test/clj_vapi/vbit_and_not_test.clj
+++ b/test/clj_vapi/vbit_and_not_test.clj
@@ -1,0 +1,41 @@
+(ns clj-vapi.vbit-and-not-test
+  (:require [clojure.test :refer :all]
+            [clj-vapi.test-utils :as tu]
+            [clj-vapi.utils :as u]
+            [clj-vapi.core :refer [vbit-and-not]]))
+
+(def in1 [2r0000 2r0001 2r0010 2r0100 2r1000 2r0011 2r0110 2r1100 2r1001])
+(def in2 [2r1111 2r1111 2r1111 2r1111 2r1111 2r0111 2r0111 2r0111 2r0110])
+(def out [2r0000 2r0000 2r0000 2r0000 2r0000 2r0000 2r0000 2r1000 2r1001])
+
+(defn run-integral-tests
+  [array-ctor]
+  (tu/equal-arrays?
+   (array-ctor out)
+   (vbit-and-not (array-ctor in1)
+                 (array-ctor in2))))
+
+(deftest vbit-and-not-test
+  (testing "vbit-and-not integral"
+    (run-integral-tests byte-array)
+    (run-integral-tests short-array)
+    (run-integral-tests int-array)
+    (run-integral-tests long-array)))
+
+(defn run-integral-2d-tests
+  [array-ctor]
+  (let [in1-2d (vec (map vec (partition 3 in1)))
+        in2-2d (vec (map vec (partition 3 in2)))
+        out-2d (vec (map vec (partition 3 out)))]
+    (tu/equal-2d-arrays?
+     (u/vec->array array-ctor out-2d)
+     (vbit-and-not (u/vec->array array-ctor in1-2d)
+                   (u/vec->array array-ctor in2-2d)))))
+
+(deftest vbit-and-not-2d-test
+  (testing "vbit-and-not-2d integral"
+    (run-integral-2d-tests byte-array)
+    (run-integral-2d-tests short-array)
+    (run-integral-2d-tests int-array)
+    (run-integral-2d-tests long-array)))
+

--- a/test/clj_vapi/vbit_and_test.clj
+++ b/test/clj_vapi/vbit_and_test.clj
@@ -1,0 +1,41 @@
+(ns clj-vapi.vbit-and-test
+  (:require [clojure.test :refer :all]
+            [clj-vapi.test-utils :as tu]
+            [clj-vapi.utils :as u]
+            [clj-vapi.core :refer [vbit-and]]))
+
+(def in1 [2r0000 2r0001 2r0010 2r0100 2r1000 2r0011 2r0110 2r1100 2r1001])
+(def in2 [2r1111 2r1111 2r1111 2r1111 2r1111 2r0111 2r0111 2r0111 2r0110])
+(def out [2r0000 2r0001 2r0010 2r0100 2r1000 2r0011 2r0110 2r0100 2r0000])
+
+(defn run-integral-tests
+  [array-ctor]
+  (tu/equal-arrays?
+   (array-ctor out)
+   (vbit-and (array-ctor in1)
+             (array-ctor in2))))
+
+(deftest vbit-and-test
+  (testing "vbit-and integral"
+    (run-integral-tests byte-array)
+    (run-integral-tests short-array)
+    (run-integral-tests int-array)
+    (run-integral-tests long-array)))
+
+(defn run-integral-2d-tests
+  [array-ctor]
+  (let [in1-2d (vec (map vec (partition 3 in1)))
+        in2-2d (vec (map vec (partition 3 in2)))
+        out-2d (vec (map vec (partition 3 out)))]
+    (tu/equal-2d-arrays?
+     (u/vec->array array-ctor out-2d)
+     (vbit-and (u/vec->array array-ctor in1-2d)
+               (u/vec->array array-ctor in2-2d)))))
+
+(deftest vbit-and-2d-test
+  (testing "vbit-and-2d integral"
+    (run-integral-2d-tests byte-array)
+    (run-integral-2d-tests short-array)
+    (run-integral-2d-tests int-array)
+    (run-integral-2d-tests long-array)))
+

--- a/test/clj_vapi/vbit_not_test.clj
+++ b/test/clj_vapi/vbit_not_test.clj
@@ -1,0 +1,48 @@
+(ns clj-vapi.vbit-not-test
+  (:require [clojure.test :refer :all]
+            [clj-vapi.test-utils :as tu]
+            [clj-vapi.utils :as u]
+            [clj-vapi.core :refer [vbit-not]]))
+
+(def bin-literals
+  [2r0000 2r0001 2r0010 2r0011
+   2r0100 2r0101 2r0110 2r0111
+   2r1000 2r1001 2r1010 2r1011
+   2r1100 2r1101 2r1110 2r1111])
+
+(def bin-literals-not (map bit-not bin-literals))
+
+(defn run-integral-tests
+  [array-ctor]
+  (tu/equal-arrays?
+   (array-ctor bin-literals-not)
+   (vbit-not (array-ctor bin-literals)))
+  (tu/equal-arrays?
+   (array-ctor bin-literals)
+   (vbit-not (array-ctor bin-literals-not))))
+
+(deftest vbit-not-test
+  (testing "vbit-not integral"
+    (run-integral-tests byte-array)
+    (run-integral-tests short-array)
+    (run-integral-tests int-array)
+    (run-integral-tests long-array)))
+
+(defn run-integral-2d-tests
+  [array-ctor]
+  (let [bit-lit-2d (vec (map vec (partition 4 bin-literals)))
+        bit-lit-not-2d (vec (map vec (partition 4 bin-literals-not)))]
+    (tu/equal-2d-arrays?
+     (u/vec->array array-ctor bit-lit-not-2d)
+     (vbit-not (u/vec->array array-ctor bit-lit-2d)))
+    (tu/equal-2d-arrays?
+     (u/vec->array array-ctor bit-lit-2d)
+     (vbit-not (u/vec->array array-ctor bit-lit-not-2d)))))
+
+(deftest vbit-not-2d-test
+  (testing "vbit-not-2d integral"
+    (run-integral-2d-tests byte-array)
+    (run-integral-2d-tests short-array)
+    (run-integral-2d-tests int-array)
+    (run-integral-2d-tests long-array)))
+

--- a/test/clj_vapi/vbit_or_test.clj
+++ b/test/clj_vapi/vbit_or_test.clj
@@ -1,0 +1,41 @@
+(ns clj-vapi.vbit-or-test
+  (:require [clojure.test :refer :all]
+            [clj-vapi.test-utils :as tu]
+            [clj-vapi.utils :as u]
+            [clj-vapi.core :refer [vbit-or]]))
+
+(def in1 [2r0000 2r0001 2r0010 2r0100 2r1000 2r0011 2r0110 2r1100 2r1001])
+(def in2 [2r1111 2r1111 2r1111 2r1111 2r1111 2r0111 2r0111 2r0111 2r0110])
+(def out [2r1111 2r1111 2r1111 2r1111 2r1111 2r0111 2r0111 2r1111 2r1111])
+
+(defn run-integral-tests
+  [array-ctor]
+  (tu/equal-arrays?
+   (array-ctor out)
+   (vbit-or (array-ctor in1)
+            (array-ctor in2))))
+
+(deftest vbit-or-test
+  (testing "vbit-or integral"
+    (run-integral-tests byte-array)
+    (run-integral-tests short-array)
+    (run-integral-tests int-array)
+    (run-integral-tests long-array)))
+
+(defn run-integral-2d-tests
+  [array-ctor]
+  (let [in1-2d (vec (map vec (partition 3 in1)))
+        in2-2d (vec (map vec (partition 3 in2)))
+        out-2d (vec (map vec (partition 3 out)))]
+    (tu/equal-2d-arrays?
+     (u/vec->array array-ctor out-2d)
+     (vbit-or (u/vec->array array-ctor in1-2d)
+              (u/vec->array array-ctor in2-2d)))))
+
+(deftest vbit-or-2d-test
+  (testing "vbit-or-2d integral"
+    (run-integral-2d-tests byte-array)
+    (run-integral-2d-tests short-array)
+    (run-integral-2d-tests int-array)
+    (run-integral-2d-tests long-array)))
+

--- a/test/clj_vapi/vbit_xor_test.clj
+++ b/test/clj_vapi/vbit_xor_test.clj
@@ -1,0 +1,41 @@
+(ns clj-vapi.vbit-xor-test
+  (:require [clojure.test :refer :all]
+            [clj-vapi.test-utils :as tu]
+            [clj-vapi.utils :as u]
+            [clj-vapi.core :refer [vbit-xor]]))
+
+(def in1 [2r0000 2r0001 2r0010 2r0100 2r1000 2r0011 2r0110 2r1100 2r1001])
+(def in2 [2r1111 2r1111 2r1111 2r1111 2r1111 2r0111 2r0111 2r0111 2r0110])
+(def out [2r1111 2r1110 2r1101 2r1011 2r0111 2r0100 2r0001 2r1011 2r1111])
+
+(defn run-integral-tests
+  [array-ctor]
+  (tu/equal-arrays?
+   (array-ctor out)
+   (vbit-xor (array-ctor in1)
+             (array-ctor in2))))
+
+(deftest vbit-xor-test
+  (testing "vbit-xor integral"
+    (run-integral-tests byte-array)
+    (run-integral-tests short-array)
+    (run-integral-tests int-array)
+    (run-integral-tests long-array)))
+
+(defn run-integral-2d-tests
+  [array-ctor]
+  (let [in1-2d (vec (map vec (partition 3 in1)))
+        in2-2d (vec (map vec (partition 3 in2)))
+        out-2d (vec (map vec (partition 3 out)))]
+    (tu/equal-2d-arrays?
+     (u/vec->array array-ctor out-2d)
+     (vbit-xor (u/vec->array array-ctor in1-2d)
+               (u/vec->array array-ctor in2-2d)))))
+
+(deftest vbit-xor-2d-test
+  (testing "vbit-xor-2d integral"
+    (run-integral-2d-tests byte-array)
+    (run-integral-2d-tests short-array)
+    (run-integral-2d-tests int-array)
+    (run-integral-2d-tests long-array)))
+


### PR DESCRIPTION
The following (vectorised) bitwise operations have been defined and unit tested on 1D and multi-dimensional arrays: `not`, `and`, `or`, `xor` and `and-not`.